### PR TITLE
fix: reduce YARA false positives by 74%

### DIFF
--- a/src/scanner.js
+++ b/src/scanner.js
@@ -215,10 +215,26 @@ class Scanner {
     
     this.results.scannedFiles++;
     
+    // Determine file type for rule filtering
+    const isDocFile = ['.md', '.mdx', '.txt', '.rst'].includes(ext);
+    
     // Apply each rule
     for (const rule of this.rules) {
+      // Skip code-focused rules for documentation files
+      if (isDocFile && this.isCodeOnlyRule(rule)) {
+        continue;
+      }
       this.applyRule(rule, filePath, content);
     }
+  }
+
+  /**
+   * Check if rule should only apply to code files (not docs)
+   */
+  isCodeOnlyRule(rule) {
+    // MCP rules and command execution rules are code-focused
+    const codeOnlyPrefixes = ['mcp-', 'command-'];
+    return codeOnlyPrefixes.some(prefix => rule.id.startsWith(prefix));
   }
 
   /**


### PR DESCRIPTION
## 問題
YARAスキャンで大量の誤検出が発生していた（162件）

## 原因
1. **AND条件のパースミス**: `(any of ($read*)) and (any of ($send*))` が正しく評価されていなかった
2. **ドキュメントファイルへの過剰検出**: .md ファイル内の説明文がコード検出ルールにマッチ

## 修正内容
- YARAの AND 条件を正しくパース
- パターングループ（$read*, $send* など）を正しく識別
- Markdownファイル (.md, .txt) ではコード系ルール (mcp-*, command-*) をスキップ

## 結果
| 段階 | 件数 | 削減 |
|------|------|------|
| 修正前 | 162件 | - |
| 修正後 | 42件 | **-74%** |

## 残りの検出（正当な警告）
- APIコール系スクリプト: 環境変数を読んでHTTP送信
- セキュリティツール自体: ルール定義の自己検出
- APIシークレット: 本物の警告