### PR TITLE
feat: .agentvetignore support

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,30 @@ YARA works in two modes:
 - **yara-cli**: Uses the native `yara` command (fastest, requires yara installed)
 - **js-fallback**: Pure JavaScript implementation (works everywhere, no dependencies)
 
+### Ignore files
+
+Create `.agentvetignore` in your project root to exclude files:
+
+```gitignore
+# Ignore test fixtures
+test/fixtures/
+
+# Ignore documentation with example patterns
+docs/*.md
+
+# Ignore backup files
+*.bak
+
+# Ignore specific security tool that contains patterns
+scripts/security-scanner.js
+```
+
+Supports gitignore-style patterns:
+- `*` matches anything except `/`
+- `**` matches everything including `/`
+- `/pattern` anchors to root
+- `pattern/` matches directories
+
 ### Exit codes
 
 | Code | Meaning |


### PR DESCRIPTION
## 概要
`.agentvetignore` ファイルで特定のファイル/ディレクトリを除外できるように。

## 機能
- プロジェクトルートの `.agentvetignore` を自動読み込み
- gitignore形式のパターンサポート
  - `*` - `/` 以外にマッチ
  - `**` - 全てにマッチ
  - `/pattern` - ルートからのパス
  - `pattern/` - ディレクトリマッチ
- 結果にignoreパターン数を表示

## 使用例
```gitignore
# テストフィクスチャを除外
test/fixtures/

# ドキュメントを除外
docs/*.md

# セキュリティツール自体を除外
scripts/security-scanner.js
```

## テスト
- 2件の新規テスト追加
- 全20テストパス ✓

## ユースケース
- セキュリティスキャナー自体のルール定義の自己検出を回避
- サンプルコード/フィクスチャの除外
- 特定の信頼済みファイルの除外