### PR TITLE
fix: apply .agentvetignore to YARA findings

### DIFF
--- a/src/scanner.js
+++ b/src/scanner.js
@@ -514,6 +514,9 @@ class Scanner {
       
       // Add YARA findings to results
       for (const finding of yaraFindings) {
+        // Skip ignored files
+        if (this.isIgnored(finding.file)) continue;
+        
         // Apply severity filter
         const severityOrder = { critical: 0, warning: 1, info: 2 };
         const filterLevel = severityOrder[this.options.severityFilter] ?? 2;


### PR DESCRIPTION
## 問題
YARAスキャン結果が `.agentvetignore` パターンを無視していた。

## 修正
YARA findingsを追加する前に `isIgnored()` をチェック。

## 結果
`~/clawd` スキャン結果:
- 修正前: 39件 critical
- 修正後: **0件** ✅

全20テストパス。